### PR TITLE
Ubuntu - Import upstream version 1.0.0~rc92

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+runc (1.0.0~rc92-0ubuntu1) UNRELEASED; urgency=medium
+
+  * New upstream release.
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Tue, 12 Jan 2021 15:58:19 -0300
+
 runc (1.0.0~rc10-0ubuntu3) hirsute; urgency=medium
 
   * No-change rebuild using new golang

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,11 @@
 runc (1.0.0~rc92-0ubuntu1) UNRELEASED; urgency=medium
 
   * New upstream release.
+  * Refresh patches.
+  * Add patch to skip tests relying on cgroups fs mountpoints.
+  * Update VCS links to point to Github where the packaging work is done.
 
- -- Lucas Kanashiro <kanashiro@ubuntu.com>  Tue, 12 Jan 2021 15:58:19 -0300
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Tue, 12 Jan 2021 17:30:36 -0300
 
 runc (1.0.0~rc10-0ubuntu3) hirsute; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-runc (1.0.0~rc92-0ubuntu1) UNRELEASED; urgency=medium
+runc (1.0.0~rc92-0ubuntu1) hirsute; urgency=medium
 
   * New upstream release.
   * Refresh patches.

--- a/debian/control
+++ b/debian/control
@@ -16,8 +16,8 @@ Build-Depends: debhelper (>= 11~),
                protobuf-compiler
 Standards-Version: 4.1.4
 Homepage: https://github.com/opencontainers/runc
-Vcs-Git: https://salsa.debian.org/go-team/packages/runc.git
-Vcs-Browser: https://salsa.debian.org/go-team/packages/runc
+Vcs-Git: https://github.com/tianon/debian-runc.git -b ubuntu
+Vcs-Browser: https://github.com/tianon/debian-runc/tree/ubuntu
 XS-Go-Import-Path: github.com/opencontainers/runc
 
 Package: runc

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 test--fix_TestGetAdditionalGroups.patch
 test--skip-Hugetlb.patch
 test--skip_TestFactoryNewTmpfs.patch
+test--skip-fs-related-cgroups-tests.patch

--- a/debian/patches/test--fix_TestGetAdditionalGroups.patch
+++ b/debian/patches/test--fix_TestGetAdditionalGroups.patch
@@ -7,8 +7,7 @@ Description: fix FTBFS on i686
 
 --- a/libcontainer/user/user_test.go
 +++ b/libcontainer/user/user_test.go
-@@ -444,9 +444,9 @@
- 
+@@ -445,7 +445,7 @@
  	if utils.GetIntSize() > 4 {
  		tests = append(tests, foo{
  			// groups with too large id
@@ -17,11 +16,9 @@ Description: fix FTBFS on i686
  			expected: nil,
  			hasError: true,
  		})
- 	}
 --- a/libcontainer/user/user.go
 +++ b/libcontainer/user/user.go
-@@ -413,9 +413,9 @@
- 			if err != nil {
+@@ -471,7 +471,7 @@
  				return nil, fmt.Errorf("Unable to find group %s", ag)
  			}
  			// Ensure gid is inside gid range.
@@ -30,4 +27,3 @@ Description: fix FTBFS on i686
  				return nil, ErrRange
  			}
  			gidMap[gid] = struct{}{}
- 		}

--- a/debian/patches/test--skip-Hugetlb.patch
+++ b/debian/patches/test--skip-Hugetlb.patch
@@ -6,8 +6,7 @@ Description: disabled unreliable tests due to random failures on [ppc64el, s390x
 
 --- a/libcontainer/cgroups/fs/hugetlb_test.go
 +++ b/libcontainer/cgroups/fs/hugetlb_test.go
-@@ -87,8 +87,9 @@
- 	}
+@@ -89,6 +89,7 @@
  }
  
  func TestHugetlbStatsNoUsageFile(t *testing.T) {
@@ -15,9 +14,7 @@ Description: disabled unreliable tests due to random failures on [ppc64el, s390x
  	helper := NewCgroupTestUtil("hugetlb", t)
  	defer helper.cleanup()
  	helper.writeFileContents(map[string]string{
- 		maxUsage: hugetlbMaxUsageContents,
-@@ -102,8 +103,9 @@
- 	}
+@@ -104,6 +105,7 @@
  }
  
  func TestHugetlbStatsNoMaxUsageFile(t *testing.T) {
@@ -25,9 +22,7 @@ Description: disabled unreliable tests due to random failures on [ppc64el, s390x
  	helper := NewCgroupTestUtil("hugetlb", t)
  	defer helper.cleanup()
  	for _, pageSize := range HugePageSizes {
- 		helper.writeFileContents(map[string]string{
-@@ -119,8 +121,9 @@
- 	}
+@@ -121,6 +123,7 @@
  }
  
  func TestHugetlbStatsBadUsageFile(t *testing.T) {
@@ -35,9 +30,7 @@ Description: disabled unreliable tests due to random failures on [ppc64el, s390x
  	helper := NewCgroupTestUtil("hugetlb", t)
  	defer helper.cleanup()
  	for _, pageSize := range HugePageSizes {
- 		helper.writeFileContents(map[string]string{
-@@ -137,8 +140,9 @@
- 	}
+@@ -139,6 +142,7 @@
  }
  
  func TestHugetlbStatsBadMaxUsageFile(t *testing.T) {
@@ -45,4 +38,3 @@ Description: disabled unreliable tests due to random failures on [ppc64el, s390x
  	helper := NewCgroupTestUtil("hugetlb", t)
  	defer helper.cleanup()
  	helper.writeFileContents(map[string]string{
- 		usage:    hugetlbUsageContents,

--- a/debian/patches/test--skip-fs-related-cgroups-tests.patch
+++ b/debian/patches/test--skip-fs-related-cgroups-tests.patch
@@ -1,0 +1,92 @@
+Description: Skip tests which rely on cgroups mountpoints on the filesystem
+ As far as I can see, cgroups mountpoints are not available in a default build
+ environment using for instance sbuild. Therefore, all the tests relying on this
+ are failing.
+Author: Lucas Kanashiro <kanashiro@ubuntu.com>
+Forwarded: not-needed
+Last-Updated: 2021-01-12
+
+--- a/libcontainer/cgroups/fs/fs_test.go
++++ b/libcontainer/cgroups/fs/fs_test.go
+@@ -12,6 +12,7 @@
+ )
+ 
+ func TestInvalidCgroupPath(t *testing.T) {
++	t.Skip("UM - SIGSEGV due to invalid memory access")
+ 	if cgroups.IsCgroup2UnifiedMode() {
+ 		t.Skip("cgroup v2 is not supported")
+ 	}
+@@ -46,6 +47,7 @@
+ }
+ 
+ func TestInvalidAbsoluteCgroupPath(t *testing.T) {
++	t.Skip("UM - SIGSEGV due to invalid memory access")
+ 	if cgroups.IsCgroup2UnifiedMode() {
+ 		t.Skip("cgroup v2 is not supported")
+ 	}
+@@ -81,6 +83,7 @@
+ 
+ // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
+ func TestInvalidCgroupParent(t *testing.T) {
++	t.Skip("UM - SIGSEGV due to invalid memory access")
+ 	if cgroups.IsCgroup2UnifiedMode() {
+ 		t.Skip("cgroup v2 is not supported")
+ 	}
+@@ -117,6 +120,7 @@
+ 
+ // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
+ func TestInvalidAbsoluteCgroupParent(t *testing.T) {
++	t.Skip("UM - SIGSEGV due to invalid memory access")
+ 	if cgroups.IsCgroup2UnifiedMode() {
+ 		t.Skip("cgroup v2 is not supported")
+ 	}
+@@ -153,6 +157,7 @@
+ 
+ // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
+ func TestInvalidCgroupName(t *testing.T) {
++	t.Skip("UM - SIGSEGV due to invalid memory access")
+ 	if cgroups.IsCgroup2UnifiedMode() {
+ 		t.Skip("cgroup v2 is not supported")
+ 	}
+@@ -190,6 +195,7 @@
+ 
+ // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
+ func TestInvalidAbsoluteCgroupName(t *testing.T) {
++	t.Skip("UM - SIGSEGV due to invalid memory access")
+ 	if cgroups.IsCgroup2UnifiedMode() {
+ 		t.Skip("cgroup v2 is not supported")
+ 	}
+@@ -226,6 +232,7 @@
+ 
+ // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
+ func TestInvalidCgroupNameAndParent(t *testing.T) {
++	t.Skip("UM - SIGSEGV due to invalid memory access")
+ 	if cgroups.IsCgroup2UnifiedMode() {
+ 		t.Skip("cgroup v2 is not supported")
+ 	}
+@@ -262,6 +269,7 @@
+ 
+ // XXX: Remove me after we get rid of configs.Cgroup.Name and configs.Cgroup.Parent.
+ func TestInvalidAbsoluteCgroupNameAndParent(t *testing.T) {
++	t.Skip("UM - SIGSEGV due to invalid memory access")
+ 	if cgroups.IsCgroup2UnifiedMode() {
+ 		t.Skip("cgroup v2 is not supported")
+ 	}
+@@ -297,6 +305,7 @@
+ }
+ 
+ func TestTryDefaultCgroupRoot(t *testing.T) {
++	t.Skip("UM - Cgroup mountpoint is not available during build time")
+ 	res := tryDefaultCgroupRoot()
+ 	exp := defaultCgroupRoot
+ 	if cgroups.IsCgroup2UnifiedMode() {
+--- a/libcontainer/cgroups/fscommon/fscommon_test.go
++++ b/libcontainer/cgroups/fscommon/fscommon_test.go
+@@ -14,6 +14,7 @@
+ )
+ 
+ func TestWriteCgroupFileHandlesInterrupt(t *testing.T) {
++	t.Skip("UM - No cgroup mountpoint in memory during build time")
+ 	if cgroups.IsCgroup2UnifiedMode() {
+ 		t.Skip("cgroup v2 is not supported")
+ 	}

--- a/debian/patches/test--skip_TestFactoryNewTmpfs.patch
+++ b/debian/patches/test--skip_TestFactoryNewTmpfs.patch
@@ -5,8 +5,7 @@ Description: disable test (requires root)
 
 --- a/libcontainer/factory_linux_test.go
 +++ b/libcontainer/factory_linux_test.go
-@@ -76,8 +76,9 @@
- 	}
+@@ -78,6 +78,7 @@
  }
  
  func TestFactoryNewTmpfs(t *testing.T) {
@@ -14,4 +13,3 @@ Description: disable test (requires root)
  	root, rerr := newTestRoot()
  	if rerr != nil {
  		t.Fatal(rerr)
- 	}


### PR DESCRIPTION
I'd like to upload this package together with `containerd` and `docker.io`, so this is more a review of the packaging work, some integration tests should be done before uploading them all.

I uploaded the proposed package to this PPA:

https://launchpad.net/~lucaskanashiro/+archive/ubuntu/docker-20.10

autopkgtest is happy with this new version (Hirsute env):

```
autopkgtest [18:10:14]: @@@@@@@@@@@@@@@@@@@@ summary
basic-smoke          PASS
command1             PASS
```

The only change I am not quite sure if the solution I proposed is the best one is adding the patch to skip some tests relying on cgroups fs mountpoints. Those tests were failing, and after getting a shell from my schroot env managed by sbuild I noticed that there is no mountpoint for cgroups, so I decided to skip them.