### PR TITLE
Add patch for cpuset range byte order issue

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+runc (1.1.2-0ubuntu1.1) kinetic; urgency=medium
+
+  * d/p/fix_cpuset_range_byte_order.patch: fix byte order while parsing cpuset
+    range to bits (LP: #1993221)
+
+ -- Chengen Du <chengen.du@canonical.com>  Mon, 17 Oct 2022 15:59:43 +0800
+
 runc (1.1.2-0ubuntu1) kinetic; urgency=medium
 
   * New upstream release.

--- a/debian/patches/fix_cpuset_range_byte_order.patch
+++ b/debian/patches/fix_cpuset_range_byte_order.patch
@@ -1,0 +1,103 @@
+Description: Fix byte order while parsing cpuset range to bits
+ Runc parses cpuset range to bits in the case of cgroup v2 + systemd as cgroup driver.
+ The byte order representation differs from systemd expectation,
+ which will set different cpuset range in systemd transient unit if the length of parsed byte array exceeds one.
+
+Author: seyeongkim <seyeong.kim@canonical.com>, Chengen Du <chengen.du@canonical.com>
+
+Origin: upstream, https://github.com/opencontainers/runc/commit/70e3b757c0eb39221aa5a4dbeb723c88f348f5cd
+Bug: https://github.com/opencontainers/runc/pull/3611
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1993221
+Last-Update: 2022-10-17
+Index: runc-1.1.2/libcontainer/cgroups/systemd/cpuset.go
+===================================================================
+--- runc-1.1.2.orig/libcontainer/cgroups/systemd/cpuset.go
++++ runc-1.1.2/libcontainer/cgroups/systemd/cpuset.go
+@@ -51,5 +51,10 @@ func RangeToBits(str string) ([]byte, er
+ 		// do not allow empty values
+ 		return nil, errors.New("empty value")
+ 	}
++
++	// fit cpuset parsing order in systemd
++	for l, r := 0, len(ret)-1; l < r; l, r = l+1, r-1 {
++		ret[l], ret[r] = ret[r], ret[l]
++	}
+ 	return ret, nil
+ }
+Index: runc-1.1.2/libcontainer/cgroups/systemd/cpuset_test.go
+===================================================================
+--- runc-1.1.2.orig/libcontainer/cgroups/systemd/cpuset_test.go
++++ runc-1.1.2/libcontainer/cgroups/systemd/cpuset_test.go
+@@ -22,13 +22,13 @@ func TestRangeToBits(t *testing.T) {
+ 		{in: "4-7", out: []byte{0xf0}},
+ 		{in: "0-7", out: []byte{0xff}},
+ 		{in: "0-15", out: []byte{0xff, 0xff}},
+-		{in: "16", out: []byte{1, 0, 0}},
+-		{in: "0-3,32-33", out: []byte{3, 0, 0, 0, 0x0f}},
++		{in: "16", out: []byte{0, 0, 1}},
++		{in: "0-3,32-33", out: []byte{0x0f, 0, 0, 0, 3}},
+ 		// extra spaces and tabs are ok
+ 		{in: "1, 2, 1-2", out: []byte{6}},
+ 		{in: "    , 1   , 3  ,  5-7,	", out: []byte{0xea}},
+ 		// somewhat large values
+-		{in: "128-130,1", out: []byte{7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}},
++		{in: "128-130,1", out: []byte{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7}},
+ 
+ 		{in: "-", isErr: true},
+ 		{in: "1-", isErr: true},
+Index: runc-1.1.2/tests/integration/helpers.bash
+===================================================================
+--- runc-1.1.2.orig/tests/integration/helpers.bash
++++ runc-1.1.2/tests/integration/helpers.bash
+@@ -448,6 +448,13 @@ function requires() {
+ 				skip_me=1
+ 			fi
+ 			;;
++		more_than_8_core)
++			local cpus
++			cpus=$(grep -c '^processor' /proc/cpuinfo)
++			if [ "$cpus" -le 8 ]; then
++				skip_me=1
++			fi
++			;;
+ 		*)
+ 			fail "BUG: Invalid requires $var."
+ 			;;
+Index: runc-1.1.2/tests/integration/update.bats
+===================================================================
+--- runc-1.1.2.orig/tests/integration/update.bats
++++ runc-1.1.2/tests/integration/update.bats
+@@ -559,6 +559,33 @@ EOF
+ 	check_systemd_value "AllowedMemoryNodes" 1
+ }
+ 
++@test "update cpuset cpus range via v2 unified map" {
++	# This test assumes systemd >= v244
++	[ $EUID -ne 0 ] && requires rootless_cgroup
++	requires systemd cgroups_v2 more_than_8_core cgroups_cpuset
++
++	update_config ' .linux.resources.unified |= {
++				"cpuset.cpus": "0-5",
++			}'
++	runc run -d --console-socket "$CONSOLE_SOCKET" test_update
++	[ "$status" -eq 0 ]
++
++	# check that the initial value was properly set
++	check_systemd_value "AllowedCPUs" "0-5"
++
++	runc update -r - test_update <<EOF
++{
++  "unified": {
++    "cpuset.cpus": "5-8"
++  }
++}
++EOF
++	[ "$status" -eq 0 ]
++
++	# check the updated systemd unit property, the value should not be affected by byte order
++	check_systemd_value "AllowedCPUs" "5-8"
++}
++
+ @test "update rt period and runtime" {
+ 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+ 	requires cgroups_v1 cgroups_rt no_systemd

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 test--skip_TestFactoryNewTmpfs.patch
 test--skip-fs-related-cgroups-tests.patch
+fix_cpuset_range_byte_order.patch


### PR DESCRIPTION
### [Impact]
Runc parses cpuset range to bits in the case of cgroup v2 + systemd as cgroup driver.
The byte order representation differs from systemd expectation,
which will set different cpuset range in systemd transient unit if the length of parsed byte array exceeds one.
The cpuset.cpus in cgroup will also be set to wrong value after reloading systemd manager configuration.

### [Test Plan]
\# cat config.json
...
"resources": {
 ...
 "cpu": {
  "cpus": "10-23"
 }
},
...
\# runc --systemd-cgroup run test
\# cat /run/systemd/transient/runc-test.scope.d/50-AllowedCPUs.conf
\# This is a drop-in unit file extension, created via "systemctl set-property"
\# or an equivalent operation. Do not edit.
[Scope]
AllowedCPUs=0-7 10-15
\# systemctl daemon-reload
\# cat /sys/fs/cgroup/system.slice/runc-test.scope/cpuset.cpus
0-7,10-15`

### [Where problems could occur]
Using the same byte order with systemd makes the parser be endian free.
The regression can be considered as low.

### [Other Info]

@lucaskanashiro Please help to review the PR, thanks.