### PR TITLE
Add /dev/ file fix to lunar

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+runc (1.1.4-0ubuntu3) lunar; urgency=medium
+
+  * d/p/lp2013318-fix-device-files-in-containers.patch: Fix inability to use
+    device files such as /dev/null in containers (LP: #2013318)
+
+ -- Lena Voytek <lena.voytek@canonical.com>  Thu, 06 Apr 2023 10:57:46 -0700
+
 runc (1.1.4-0ubuntu2) lunar-proposed; urgency=medium
 
   * Import blockIODevice.patch from Debian (LP: #2009851)

--- a/debian/patches/lp2013318-fix-device-files-in-containers.patch
+++ b/debian/patches/lp2013318-fix-device-files-in-containers.patch
@@ -1,0 +1,30 @@
+Description: Fix inability to use /dev/null when inside a container
+Author: Evan Phoenix <evan@phx.io>
+Origin: upstream, https://github.com/opencontainers/runc/commit/462e719cae227a990ed793241062a8d2d6145332
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/runc/+bug/2013318
+Last-Update: 2023-04-06
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/libcontainer/cgroups/systemd/common.go
++++ b/libcontainer/cgroups/systemd/common.go
+@@ -293,8 +293,18 @@
+ 			// rules separately to systemd) we can safely skip entries that don't
+ 			// have a corresponding path.
+ 			if _, err := os.Stat(entry.Path); err != nil {
+-				logrus.Debugf("skipping device %s for systemd: %s", entry.Path, err)
+-				continue
++				// Also check /sys/dev so that we don't depend on /dev/{block,char}
++				// being populated. (/dev/{block,char} is populated by udev, which
++				// isn't strictly required for systemd). Ironically, this happens most
++				// easily when starting containerd within a runc created container
++				// itself.
++
++				// We don't bother with securejoin here because we create entry.Path
++				// right above here, so we know it's safe.
++				if _, err := os.Stat("/sys" + entry.Path); err != nil {
++					logrus.Warnf("skipping device %s for systemd: %s", entry.Path, err)
++					continue
++				}
+ 			}
+ 		}
+ 		deviceAllowList = append(deviceAllowList, entry)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@ test--skip_TestFactoryNewTmpfs.patch
 test--skip-fs-related-cgroups-tests.patch
 fix_cpuset_range_byte_order.patch
 0011-export-blockIODevice.patch
+lp2013318-fix-device-files-in-containers.patch


### PR DESCRIPTION
These commits add a patch from upstream commit to fix a problem users are having in docker where they can't access /dev/ files such as /dev/null. This will be fixed when runc 1.1.5 is backported to Ubuntu, but users have shown a need to have this update sooner. 

The original bug report in Ubuntu is here: https://bugs.launchpad.net/ubuntu/+source/runc/+bug/2013318

I created a PPA for testing this fix here: https://launchpad.net/~lvoytek/+archive/ubuntu/runc-fix-dev-in-containers