### PR TITLE
Add /dev/ file fix to kinetic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+runc (1.1.4-0ubuntu1~22.10.2) kinetic; urgency=medium
+
+  * d/p/lp2013318-fix-device-files-in-containers.patch: Fix inability to use
+    device files such as /dev/null in containers (LP: #2013318)
+
+ -- Lena Voytek <lena.voytek@canonical.com>  Wed, 12 Apr 2023 13:10:10 -0700
+
 runc (1.1.4-0ubuntu1~22.10.1) kinetic; urgency=medium
 
   * Backport version 1.1.4-0ubuntu1 from Lunar (LP: #1996909).

--- a/debian/patches/lp2013318-fix-device-files-in-containers.patch
+++ b/debian/patches/lp2013318-fix-device-files-in-containers.patch
@@ -1,0 +1,30 @@
+Description: Fix inability to use /dev/null when inside a container
+Author: Evan Phoenix <evan@phx.io>
+Origin: upstream, https://github.com/opencontainers/runc/commit/462e719cae227a990ed793241062a8d2d6145332
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/runc/+bug/2013318
+Last-Update: 2023-04-06
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/libcontainer/cgroups/systemd/common.go
++++ b/libcontainer/cgroups/systemd/common.go
+@@ -293,8 +293,18 @@
+ 			// rules separately to systemd) we can safely skip entries that don't
+ 			// have a corresponding path.
+ 			if _, err := os.Stat(entry.Path); err != nil {
+-				logrus.Debugf("skipping device %s for systemd: %s", entry.Path, err)
+-				continue
++				// Also check /sys/dev so that we don't depend on /dev/{block,char}
++				// being populated. (/dev/{block,char} is populated by udev, which
++				// isn't strictly required for systemd). Ironically, this happens most
++				// easily when starting containerd within a runc created container
++				// itself.
++
++				// We don't bother with securejoin here because we create entry.Path
++				// right above here, so we know it's safe.
++				if _, err := os.Stat("/sys" + entry.Path); err != nil {
++					logrus.Warnf("skipping device %s for systemd: %s", entry.Path, err)
++					continue
++				}
+ 			}
+ 		}
+ 		deviceAllowList = append(deviceAllowList, entry)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 test--skip_TestFactoryNewTmpfs.patch
 test--skip-fs-related-cgroups-tests.patch
 fix_cpuset_range_byte_order.patch
+lp2013318-fix-device-files-in-containers.patch


### PR DESCRIPTION
These commits are the for the same fix #20 presented in lunar but are now for SRUing to Kinetic.

Original bug report in Ubuntu: https://bugs.launchpad.net/ubuntu/+source/runc/+bug/2013318
PPA: https://launchpad.net/~lvoytek/+archive/ubuntu/runc-fix-dev-in-containers

Autopkgtest results:
  runc @ amd64:
    12.04.23 21:28:07    Log 🗒️	✅     Triggers: runc/1.1.4-0ubuntu1 22.10.1ppa1
  runc @ arm64:
    12.04.23 21:51:16    Log 🗒️	✅     Triggers: runc/1.1.4-0ubuntu1 22.10.1ppa1
  runc @ armhf:
    12.04.23 21:18:02    Log 🗒️	✅     Triggers: runc/1.1.4-0ubuntu1 22.10.1ppa1
  runc @ ppc64el:
    12.04.23 21:23:07    Log 🗒️	✅     Triggers: runc/1.1.4-0ubuntu1 22.10.1ppa1
  runc @ s390x:
    12.04.23 21:24:00    Log 🗒️	✅     Triggers: runc/1.1.4-0ubuntu1 22.10.1ppa1
